### PR TITLE
Update 4.4-overfitting-and-underfitting.ipynb

### DIFF
--- a/4.4-overfitting-and-underfitting.ipynb
+++ b/4.4-overfitting-and-underfitting.ipynb
@@ -743,7 +743,7 @@
    "outputs": [],
    "source": [
     "# At training time: we drop out 50% of the units in the output\n",
-    "layer_output *= np.randint(0, high=2, size=layer_output.shape)"
+    "layer_output *= np.random.randint(0, high=2, size=layer_output.shape)"
    ]
   },
   {
@@ -785,7 +785,7 @@
    "outputs": [],
    "source": [
     "# At training time:\n",
-    "layer_output *= np.randint(0, high=2, size=layer_output.shape)\n",
+    "layer_output *= np.random.randint(0, high=2, size=layer_output.shape)\n",
     "# Note that we are scaling *up* rather scaling *down* in this case\n",
     "layer_output /= 0.5"
    ]


### PR DESCRIPTION
`np.randint` should be `np.random.randint`