### PR TITLE
Update 8.3-neural-style-transfer.ipynb

### DIFF
--- a/8.3-neural-style-transfer.ipynb
+++ b/8.3-neural-style-transfer.ipynb
@@ -98,7 +98,7 @@
     "\"content\", and `style` is a function that takes an image and computes a representation of its \"style\".\n",
     "\n",
     "Minimizing this loss would cause `style(generated_image)` to be close to `style(reference_image)`, while `content(generated_image)` would \n",
-    "be close to `content(generated_image)`, thus achieving style transfer as we defined it.\n",
+    "be close to `content(original_image)`, thus achieving style transfer as we defined it.\n",
     "\n",
     "A fundamental observation made by Gatys et al is that deep convolutional neural networks offer precisely a way to mathematically defined \n",
     "the `style` and `content` functions. Let's see how."


### PR DESCRIPTION
typos:
generated_image-->original_image