### PR TITLE
updated 3.5 movie-reviews -- fixes key error when plotting learning curves

### DIFF
--- a/3.5-classifying-movie-reviews.ipynb
+++ b/3.5-classifying-movie-reviews.ipynb
@@ -812,8 +812,8 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "acc = history.history['acc']\n",
-    "val_acc = history.history['val_acc']\n",
+    "acc = history.history['binary_accuracy']\n",
+    "val_acc = history.history['val_binary_accuracy']\n",
     "loss = history.history['loss']\n",
     "val_loss = history.history['val_loss']\n",
     "\n",
@@ -849,8 +849,8 @@
    ],
    "source": [
     "plt.clf()   # clear figure\n",
-    "acc_values = history_dict['acc']\n",
-    "val_acc_values = history_dict['val_acc']\n",
+    "acc_values = history_dict['binary_accuracy']\n",
+    "val_acc_values = history_dict['val_binary_accuracy']\n",
     "\n",
     "plt.plot(epochs, acc, 'bo', label='Training acc')\n",
     "plt.plot(epochs, val_acc, 'b', label='Validation acc')\n",


### PR DESCRIPTION
Not sure how it happened, but if you just hit restart+run all on this notebook, it doesn't run all the way through.
There is a key error that got introduced somewhere in the development of this notebook.
I fixed those so you can now run the notebook without errors as is.