### PR TITLE
Open code sample notebooks in GPU-powered JupyterLab IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ These notebooks use Python 3.6 and Keras 2.0.8. They were generated on a p2.xlar
     * [8.4: Generating images with VAEs](http://nbviewer.jupyter.org/github/fchollet/deep-learning-with-python-notebooks/blob/master/8.4-generating-images-with-vaes.ipynb)
     * [8.5: Introduction to GANs](http://nbviewer.jupyter.org/github/fchollet/deep-learning-with-python-notebooks/blob/master/8.5-introduction-to-gans.ipynb
 )
+
+
+## Try it now
+
+[![Run on FloydHub](https://static.floydhub.com/button/button.svg)](https://floydhub.com/run)
+
+Click this button to run these notebooks in a GPU-powered JupyterLab environment

--- a/floyd.yml
+++ b/floyd.yml
@@ -1,0 +1,5 @@
+env: tensorflow-1.8
+machine: gpu
+input:
+  - source: redeipirati/datasets/cats_and_dogs_small/1
+    destination: input

--- a/floyd.yml
+++ b/floyd.yml
@@ -1,5 +1,5 @@
 env: tensorflow-1.8
 machine: gpu
-input:
+data:
   - source: redeipirati/datasets/cats_and_dogs_small/1
     destination: input


### PR DESCRIPTION
* Adds a button to open the code sample notebooks in a GPU-powered JupyterLab IDE (and also attach the Kaggle dogs and cats dataset)