### PR TITLE
added missing multiplication 0.5 from the sampling function

### DIFF
--- a/8.4-generating-images-with-vaes.ipynb
+++ b/8.4-generating-images-with-vaes.ipynb
@@ -202,7 +202,7 @@
     "    z_mean, z_log_var = args\n",
     "    epsilon = K.random_normal(shape=(K.shape(z_mean)[0], latent_dim),\n",
     "                              mean=0., stddev=1.)\n",
-    "    return z_mean + K.exp(z_log_var) * epsilon\n",
+    "    return z_mean + K.exp(0.5 * z_log_var) * epsilon\n",
     "\n",
     "z = layers.Lambda(sampling)([z_mean, z_log_var])"
    ]


### PR DESCRIPTION
In 8.4 notebook, there is a missing multiplication at the sampling function. The code 8-24 in the book is correct but it is not in the notebook.