### PR TITLE
Update 6.1-using-word-embeddings.ipynb

### DIFF
--- a/6.1-using-word-embeddings.ipynb
+++ b/6.1-using-word-embeddings.ipynb
@@ -354,7 +354,7 @@
     "    dir_name = os.path.join(train_dir, label_type)\n",
     "    for fname in os.listdir(dir_name):\n",
     "        if fname[-4:] == '.txt':\n",
-    "            f = open(os.path.join(dir_name, fname))\n",
+    "            f = open(os.path.join(dir_name, fname), encoding = "utf8")\n",
     "            texts.append(f.read())\n",
     "            f.close()\n",
     "            if label_type == 'neg':\n",


### PR DESCRIPTION
On running the cell under "Putting it all together:  from raw text to word embeddings", the kernel throws the following error:
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1757: character maps to <undefined>

This is because the dataset stored at the link provided doesn't encode files in the utf8 format, specifying that as a parameter when opening the files prevents this error.