### PR TITLE
Update chapter11_part02_sequence-models.ipynb

### DIFF
--- a/chapter11_part02_sequence-models.ipynb
+++ b/chapter11_part02_sequence-models.ipynb
@@ -123,7 +123,7 @@
     "text_vectorization.adapt(text_only_train_ds)\n",
     "\n",
     "int_train_ds = train_ds.map(\n",
-    "    lambda x, y: (text_vectorization(x), y)),\n",
+    "    lambda x, y: (text_vectorization(x), y),\n",
     "    num_parallel_calls=4)\n",
     "int_val_ds = val_ds.map(\n",
     "    lambda x, y: (text_vectorization(x), y),\n",


### PR DESCRIPTION
Remove the extra `)` that is causing error.

Original
```
int_train_ds = train_ds.map(
    lambda x, y: (text_vectorization(x), y)),
    num_parallel_calls=4)
```

Updated
```
int_train_ds = train_ds.map(
    lambda x, y: (text_vectorization(x), y),
    num_parallel_calls=4)
```