### PR TITLE
Update chapter12_part05_gans.ipynb

### DIFF
--- a/chapter12_part05_gans.ipynb
+++ b/chapter12_part05_gans.ipynb
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "from tensorflow import keras\n",
-    "dataset = keras.utils_dataset_from_directory(\n",
+    "dataset = utils.image_dataset_from_directory(\n",
     "    \"celeba_gan\",\n",
     "    label_mode=None,\n",
     "    image_size=(64, 64),\n",

--- a/chapter12_part05_gans.ipynb
+++ b/chapter12_part05_gans.ipynb
@@ -85,7 +85,7 @@
    "outputs": [],
    "source": [
     "from tensorflow import keras\n",
-    "dataset = utils.image_dataset_from_directory(\n",
+    "dataset = keras.utils.image_dataset_from_directory(\n",
     "    \"celeba_gan\",\n",
     "    label_mode=None,\n",
     "    image_size=(64, 64),\n",


### PR DESCRIPTION
Changed `keras.utils_dataset_from_directory` to `keras.utils.image_dataset_from_directory` to resolve the following error

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-12-9aa24dbc92fc> in <module>()
      1 from tensorflow import keras
----> 2 dataset = keras.utils_dataset_from_directory(
      3     "celeba_gan",
      4     label_mode=None,
      5     image_size=(64, 64),

AttributeError: module 'tensorflow.keras' has no attribute 'utils_dataset_from_directory'
```