### PR TITLE
Update chapter13_best-practices-for-the-real-world.ipynb - kerastuner

### DIFF
--- a/chapter13_best-practices-for-the-real-world.ipynb
+++ b/chapter13_best-practices-for-the-real-world.ipynb
@@ -107,7 +107,7 @@
    },
    "outputs": [],
    "source": [
-    "import kerastuner as kt\n",
+    "import keras_tuner as kt\n",
     "\n",
     "class SimpleMLP(kt.HyperModel):\n",
     "    def __init__(self, num_classes):\n",


### PR DESCRIPTION
`import kerastuner` is deprecated, please use `import keras_tuner`. 