### PR TITLE
fix typo of downloaded file

### DIFF
--- a/chapter08_intro-to-dl-for-computer-vision.ipynb
+++ b/chapter08_intro-to-dl-for-computer-vision.ipynb
@@ -272,7 +272,7 @@
    },
    "outputs": [],
    "source": [
-    "!unzip -qq train.zip"
+    "!unzip -qq dogs-vs-cats.zip"
    ]
   },
   {

--- a/chapter08_intro-to-dl-for-computer-vision.ipynb
+++ b/chapter08_intro-to-dl-for-computer-vision.ipynb
@@ -276,6 +276,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "colab_type": "code"
+   },
+   "outputs": [],
+   "source": [
+    "!unzip -qq train.zip"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text"


### PR DESCRIPTION
the downloaded file is named `dogs-vs-cats.zip` and not `train.zip`.