### PR TITLE
Added missing temperature parameter to call to function sample_next().

### DIFF
--- a/chapter12_part01_text-generation.ipynb
+++ b/chapter12_part01_text-generation.ipynb
@@ -407,6 +407,7 @@
     "                predictions = self.model(tokenized_sentence)\n",
     "                next_token = sample_next(\n",
     "                    predictions[0, self.prompt_length - 1 + i, :]\n",
+    "                    temperature		 
     "                )\n",
     "                sampled_token = tokens_index[next_token]\n",
     "                sentence += \" \" + sampled_token\n",


### PR DESCRIPTION
The text generation example (from movie review dataset) samples examples every iteration and wants to use different temperatures to do so. However the temperature variable was not passed on and hence only the default temperature=1.0 was used in each sampling. 

Added explicit temperature parameter to the function call.