### PR TITLE
Fix typo in Chapter 2.2: 'fourth' → 'fifth' (#258)

### DIFF
--- a/second_edition/chapter02_mathematical-building-blocks.ipynb
+++ b/second_edition/chapter02_mathematical-building-blocks.ipynb
@@ -6,7 +6,11 @@
     "colab_type": "text"
    },
    "source": [
-    "This is a companion notebook for the book [Deep Learning with Python, Second Edition](https://www.manning.com/books/deep-learning-with-python-second-edition?a_aid=keras&a_bid=76564dff). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n\n**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n\nThis notebook was generated for TensorFlow 2.6."
+    "This is a companion notebook for the book [Deep Learning with Python, Second Edition](https://www.manning.com/books/deep-learning-with-python-second-edition?a_aid=keras&a_bid=76564dff). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n",
+    "\n",
+    "**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n",
+    "\n",
+    "This notebook was generated for TensorFlow 2.6."
    ]
   },
   {
@@ -466,7 +470,7 @@
     "colab_type": "text"
    },
    "source": [
-    "**Displaying the fourth digit**"
+    "**Displaying the fifth digit**"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the typo mentioned in issue #258.

In the "Key Attributes" section of Chapter 2.2, the text says:
> “Displaying the fourth digit”

However, the code uses `train_images[4]`, which corresponds to the **fifth** element (Python is 0-indexed).  
Updated the markdown to read “fifth” for consistency.

File modified:
- `second_edition/chapter02_mathematical-building-blocks.ipynb`

Closes #258
