### PR TITLE
[CH8] Fix missing conv_base.trainable for fine-tuning (#257)

### DIFF
--- a/chapter08_image-classification.ipynb
+++ b/chapter08_image-classification.ipynb
@@ -6,7 +6,11 @@
     "colab_type": "text"
    },
    "source": [
-    "This is a companion notebook for the book [Deep Learning with Python, Third Edition](https://www.manning.com/books/deep-learning-with-python-third-edition). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n\n**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n\nThe book's contents are available online at [deeplearningwithpython.io](https://deeplearningwithpython.io)."
+    "This is a companion notebook for the book [Deep Learning with Python, Third Edition](https://www.manning.com/books/deep-learning-with-python-third-edition). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n",
+    "\n",
+    "**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n",
+    "\n",
+    "The book's contents are available online at [deeplearningwithpython.io](https://deeplearningwithpython.io)."
    ]
   },
   {
@@ -963,6 +967,8 @@
    },
    "outputs": [],
    "source": [
+    "conv_base.trainable = True\n",
+    "\n",
     "model.compile(\n",
     "    loss=\"binary_crossentropy\",\n",
     "    optimizer=keras.optimizers.Adam(learning_rate=1e-5),\n",

--- a/second_edition/chapter02_mathematical-building-blocks.ipynb
+++ b/second_edition/chapter02_mathematical-building-blocks.ipynb
@@ -6,7 +6,11 @@
     "colab_type": "text"
    },
    "source": [
-    "This is a companion notebook for the book [Deep Learning with Python, Second Edition](https://www.manning.com/books/deep-learning-with-python-second-edition?a_aid=keras&a_bid=76564dff). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n\n**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n\nThis notebook was generated for TensorFlow 2.6."
+    "This is a companion notebook for the book [Deep Learning with Python, Second Edition](https://www.manning.com/books/deep-learning-with-python-second-edition?a_aid=keras&a_bid=76564dff). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n",
+    "\n",
+    "**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n",
+    "\n",
+    "This notebook was generated for TensorFlow 2.6."
    ]
   },
   {
@@ -466,7 +470,7 @@
     "colab_type": "text"
    },
    "source": [
-    "**Displaying the fourth digit**"
+    "**Displaying the fifth digit**"
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR fixes an issue in Chapter 8 ("Fine-tuning a pretrained model") of the companion notebook.

### Problem
- The notebook was missing `conv_base.trainable = True` before compiling the model for fine-tuning.
- As a result, the convolutional base was never actually trained, making the "fine-tuning" section behave like feature extraction.
- This is consistent with the epoch durations being the same as feature extraction, which should have been longer for a trainable backbone.

### Solution
- Added `conv_base.trainable = True` before compiling the model.

### Issue
Fixes #257