### PR TITLE
Fix TensorFlow GradientTape example returning None due to tensor not …

### DIFF
--- a/chapter02_mathematical-building-blocks.ipynb
+++ b/chapter02_mathematical-building-blocks.ipynb
@@ -6,7 +6,11 @@
     "colab_type": "text"
    },
    "source": [
-    "This is a companion notebook for the book [Deep Learning with Python, Third Edition](https://www.manning.com/books/deep-learning-with-python-third-edition). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n\n**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n\nThe book's contents are available online at [deeplearningwithpython.io](https://deeplearningwithpython.io)."
+    "This is a companion notebook for the book [Deep Learning with Python, Third Edition](https://www.manning.com/books/deep-learning-with-python-third-edition). For readability, it only contains runnable code blocks and section titles, and omits everything else in the book: text paragraphs, figures, and pseudocode.\n",
+    "\n",
+    "**If you want to be able to follow what's going on, I recommend reading the notebook side by side with your copy of the book.**\n",
+    "\n",
+    "The book's contents are available online at [deeplearningwithpython.io](https://deeplearningwithpython.io)."
    ]
   },
   {
@@ -1316,17 +1320,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": 1,
    "metadata": {
     "colab_type": "code"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "UsageError: Cell magic `%%backend` not found.\n"
+     ]
+    }
+   ],
    "source": [
     "%%backend tensorflow\n",
     "import tensorflow as tf\n",
     "\n",
     "x = tf.zeros(shape=())\n",
     "with tf.GradientTape() as tape:\n",
+    "    # Explicitly tell the tape to track x, since tensors created with tf.zeros\n",
+    "    # are not automatically watched (only tf.Variable objects are).\n",
+    "    tape.watch(x)\n",
     "    y = 2 * x + 3\n",
     "grad_of_y_wrt_x = tape.gradient(y, x)"
    ]
@@ -1449,7 +1464,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix incorrect TensorFlow GradientTape example in Chapter 2

The original example initializes `x` using `tf.zeros()`, which creates a Tensor that is not automatically watched by `GradientTape`. As a result, the gradient computation returns `NoneType`.

This PR add explicitly the scalar tensor to be watched so it can be tracked by te gradient. Alternatively the scalar tensor could have been initialised as `tf.Variable(0.0)` which are automatically tracked.

Tested with TensorFlow 2.x.