### PR TITLE
fix broken link to moby dick txt file

### DIFF
--- a/chapter14_text-classification.ipynb
+++ b/chapter14_text-classification.ipynb
@@ -278,7 +278,7 @@
     "import keras\n",
     "\n",
     "filename = keras.utils.get_file(\n",
-    "    origin=\"https://www.gutenberg.org/files/2701/old/moby10b.txt\",\n",
+    "    origin=\"https://www.gutenberg.org/files/2701/2701-0.txt\",\n",
     ")\n",
     "moby_dick = list(open(filename, \"r\"))\n",
     "\n",


### PR DESCRIPTION
the following link returns a 404: https://www.gutenberg.org/files/2701/old/moby10b.txt. a working alternative is: https://www.gutenberg.org/files/2701/2701-0.txt